### PR TITLE
change the import css file path in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Windows might resemble:
 ```
 {
   "vscode_custom_css.imports": [
-    "file://C:/Users/{your username}/synthwave84.css"
+    "file:///C:/Users/{your username}/synthwave84.css"
     ]
 }
 ```


### PR DESCRIPTION
In Windows, the css file path should be `"file:///C:/Users/{your username}/synthwave84.css"`. See it in https://github.com/be5invis/vscode-custom-css.