### PR TITLE
fix: make codelens foreground visible

### DIFF
--- a/themes/synthwave-color-theme.json
+++ b/themes/synthwave-color-theme.json
@@ -70,7 +70,7 @@
     "editorIndentGuide.background": "#49549539",
     "editorIndentGuide.activeBackground": "#2a2139",
     "editorRuler.foreground": "#34294f33",
-    "editorCodeLens.foreground": "#34294f59",
+    "editorCodeLens.foreground": "#ffffffcc",
     "editorBracketMatch.background": "#34294f66",
     "editorBracketMatch.border": "#495495",
     "editorOverviewRuler.border": "#34294fb3",


### PR DESCRIPTION
Shows up as:

![image](https://user-images.githubusercontent.com/28659384/56978059-f4ddcb80-6b76-11e9-96db-042f211c9dc1.png)

And as hovered (this isn't possible to change AFAIK):

![image](https://user-images.githubusercontent.com/28659384/56978171-38383a00-6b77-11e9-8603-905bc29c923c.png)


Closes #12, feel free to change the color 😃
