### PR TITLE
Fix active tab stripe overlap with bottom border

### DIFF
--- a/synthwave84-noglow.css
+++ b/synthwave84-noglow.css
@@ -33,6 +33,7 @@
   height: 4px;
   background: linear-gradient(to right, #fc28a8, #03edf9) !important;
   opacity: 1;
+  z-index: 6;
 }
 
 .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab.sizing-fit::after {
@@ -44,6 +45,7 @@
   height: 0px;
   transition: opacity 1s;
   opacity: 0;
+  z-index: 6;
 }
 
 /* Active sidebar item */

--- a/synthwave84.css
+++ b/synthwave84.css
@@ -66,6 +66,7 @@
   height: 4px;
   background: linear-gradient(to right, #fc28a8, #03edf9) !important;
   opacity: 1;
+  z-index: 6;
 }
 
 .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab.sizing-fit::after {
@@ -77,6 +78,7 @@
   height: 0px;
   transition: opacity 1s;
   opacity: 0;
+  z-index: 6;
 }
 
 /* Active sidebar item */


### PR DESCRIPTION
Whenever a tab is active, the stripe gradient overlaps with the bottom border. Adding a z-index to the stripe fixes that.

Before:
![image](https://user-images.githubusercontent.com/44413349/57075030-4d83a480-6cee-11e9-90fe-7241d7cf2752.png)

After:
![image](https://user-images.githubusercontent.com/44413349/57075058-5eccb100-6cee-11e9-8ca0-5cf7444d9d28.png)
