### PR TITLE
Adds different color for object path

### DIFF
--- a/themes/synthwave-color-theme.json
+++ b/themes/synthwave-color-theme.json
@@ -422,6 +422,13 @@
       }
     },
     {
+      "name": "JS object path",
+      "scope": "variable.other.constant.property.js, variable.other.property.js",
+      "settings": {
+        "foreground": "#2ee2fa"
+      },
+    },
+    {
       "name": "Color",
       "scope": "constant.other.color",
       "settings": {


### PR DESCRIPTION
Adds a contrasting color to the last part of the object path in JS.

Before: 

<img width="359" alt="Screen Shot 2019-05-02 at 2 57 14 AM" src="https://user-images.githubusercontent.com/10368230/57053457-1aa5c600-6c86-11e9-92ad-97fbf273d2be.png">

After:

<img width="363" alt="Screen Shot 2019-05-02 at 2 56 54 AM" src="https://user-images.githubusercontent.com/10368230/57053465-27c2b500-6c86-11e9-87fe-5ca7511e1d2e.png">

Fixes #31