### PR TITLE
Fix highlight extending beyond selected text

### DIFF
--- a/synthwave84-noglow.css
+++ b/synthwave84-noglow.css
@@ -1,5 +1,5 @@
 
-.monaco-editor .margin, .monaco-editor-background, .monaco-editor .inputarea.ime-input {
+.monaco-editor .margin, .monaco-editor .inputarea.ime-input {
   background: transparent;
 }
 

--- a/synthwave84.css
+++ b/synthwave84.css
@@ -32,7 +32,7 @@
   text-shadow: 0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;
 }
 
-.monaco-editor .margin, .monaco-editor-background, .monaco-editor .inputarea.ime-input {
+.monaco-editor .margin, .monaco-editor .inputarea.ime-input {
   background: transparent;
 }
 


### PR DESCRIPTION
I haven't seen this issue reported by anyone else, but I'm running VSCode Insider's and noticed that with `Custom CSS and JS` enabled, when you select text across lines it can result in the highlight color extending beyond what's actually selected:

![highlight-issue](https://user-images.githubusercontent.com/1650029/58340605-17bf7080-7e01-11e9-8f5b-4f6044df70cb.gif)

I figured out what piece of CSS was causing the issue and removed it:

![highlight-issue-fix](https://user-images.githubusercontent.com/1650029/58340636-29a11380-7e01-11e9-9d4a-ab7fd7445de6.gif)