### PR TITLE
Fix WSL button and C placeholders

### DIFF
--- a/themes/synthwave-color-theme.json
+++ b/themes/synthwave-color-theme.json
@@ -106,7 +106,6 @@
     "statusBar.debuggingBackground": "#f97e72",
     "statusBar.debuggingForeground": "#08080f",
     "statusBar.noFolderBackground": "#241b2f",
-    "statusBarItem.hoverBackground": "#2a2139",
     "statusBarItem.prominentBackground": "#2a2139",
     "statusBarItem.prominentHoverBackground": "#34294f",
     "titleBar.activeBackground": "#241b2f",
@@ -519,6 +518,13 @@
       ],
       "settings": {
         "foreground": "#ff7edb"
+      }
+    },
+    {
+      "name": "C placeholder",
+      "scope": "constant.other.placeholder.c",
+      "settings": {
+        "foreground": "#36F9F6"
       }
     },
     {


### PR DESCRIPTION
This changes fixes the color of the Remote WSL button when hovering. Issue #79 

> Before
![wsl](https://user-images.githubusercontent.com/49621788/80290408-cc999600-8712-11ea-9724-b67f8b6c3b5c.gif)

> After
![wsl2](https://user-images.githubusercontent.com/49621788/80290409-cdcac300-8712-11ea-817f-327331410cfc.gif)

Also, adds a different color to the C placeholders; now are the same as the color of escape characters (like `\n`). Issue #165 

> Before
![Anotación 2020-04-25 161239](https://user-images.githubusercontent.com/49621788/80290478-31ed8700-8713-11ea-8bf2-a12d7f24b642.png)

> After
![Anotación 2020-04-25 172608](https://user-images.githubusercontent.com/49621788/80291221-e1c5f300-8719-11ea-8525-65b2c99e5277.png)