### PR TITLE
Pinned active tab, that is not the first tab bug

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -19,7 +19,7 @@
 /* Active tab neon */
 .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab.sizing-fit.active {
   box-shadow: inset 0 -5px 25px #fc28a825;
-  position: relative;
+  position: sticky;
 }
 
 /* Active tab stripe */


### PR DESCRIPTION
#182 
Fixed an issue where everything after the first pinned tab would be offset by the tab width.