### PR TITLE
Fix selecting multiple lines extending highlghts beyond selection

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1,4 +1,4 @@
-.monaco-editor .margin, .monaco-editor-background, .monaco-editor .inputarea.ime-input {
+.monaco-editor .margin, .monaco-editor .inputarea.ime-input {
   background: transparent;
 }
 


### PR DESCRIPTION
Fixes #153 
Removing `.monaco-editor-background` selector seems to fix the issue. Though I'm not sure if this would affect other style, I've tested this for quite long and not aware of any issues.