### PR TITLE
Correct brightness customisation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note: In the name of simplifying the install process and mitigating update-relat
 #### To customise the glow brightness
 In your `settings.json` add the key:
 ```
-"synthwave84.brightness": "0.45"
+"synthwave84.brightness": 0.45
 ```
 The value should be a _float value_ from 0 to 1, where 0.0 is fully transparent. The default brightness is 0.45. To avoid eye strain, avoid using higher brightness values for extended periods of time. 
 


### PR DESCRIPTION
The example value was a _string value_ which should be _float value_ as the next line state.