### PR TITLE
Remove what's new page

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -22,11 +22,11 @@ function activate(context) {
 			const d = diff(this.version, prevVersion);
 			// show again on major or minor updates
 			if (d == 'major' || d == 'minor') {
-				showUpdatePage();
+				// showUpdatePage();
 				context.globalState.update(`${this.extensionName}.version`, this.version);
 			}
 		} else {
-			showUpdatePage();
+			//showUpdatePage();
 			context.globalState.update(`${this.extensionName}.version`, this.version);
 		}
 


### PR DESCRIPTION
the what's new page functionality also seems to be broken which prevents the neon dream command being registered. Commenting these lines out basically fixes this extension for 1.60.x

I'd be happy to dive into fixing the actual what's new page, but for now this is a pretty good stop-gap.