### PR TITLE
update version before showing what's new page.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -22,12 +22,12 @@ function activate(context) {
 			const d = diff(this.version, prevVersion);
 			// show again on major or minor updates
 			if (d == 'major' || d == 'minor') {
-				showUpdatePage();
 				context.globalState.update(`${this.extensionName}.version`, this.version);
+				showUpdatePage();	
 			}
 		} else {
-			showUpdatePage();
 			context.globalState.update(`${this.extensionName}.version`, this.version);
+			showUpdatePage();
 		}
 
 	}


### PR DESCRIPTION
prevents a webview failure from causing the update view to be displayed every time vscode is launched.

Related to https://github.com/robb0wen/synthwave-vscode/issues/217