### PR TITLE
Add latest vscodeinsiders fix to admin privileges

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -27,17 +27,21 @@ function activate(context) {
 		const appDir = path.dirname(require.main.filename);
 		const base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
 
+		const sandboxPath = base + (isWin ? "\\electron-sandbox" : "/electron-sandbox");
+		const usesSandbox = fs.existsSync(sandboxPath);
+		const electronPath = usesSandbox ? 'electron-sandbox' : 'electron-browser';
+
 		const htmlFile =
 			base +
 			(isWin
-				? "\\electron-sandbox\\workbench\\workbench.html"
-				: "/electron-sandbox/workbench/workbench.html");
+				? `\\${electronPath}\\workbench\\workbench.html`
+				: `/${electronPath}/workbench/workbench.html`);
 
 		const templateFile =
 				base +
 				(isWin
-					? "\\electron-sandbox\\workbench\\neondreams.js"
-					: "/electron-sandbox/workbench/neondreams.js");
+					? `\\${electronPath}\\workbench\\neondreams.js`
+					: `/${electronPath}/workbench/neondreams.js`);
 
 		try {
 
@@ -106,11 +110,16 @@ function uninstall() {
 	var isWin = /^win/.test(process.platform);
 	var appDir = path.dirname(require.main.filename);
 	var base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
-	var htmlFile =
+	
+	const sandboxPath = base + (isWin ? "\\electron-sandbox" : "/electron-sandbox");
+	const usesSandbox = fs.existsSync(sandboxPath);
+	const electronPath = usesSandbox ? 'electron-sandbox' : 'electron-browser';
+
+	const htmlFile =
 		base +
 		(isWin
-			? "\\electron-sandbox\\workbench\\workbench.html"
-			: "/electron-sandbox/workbench/workbench.html");
+			? `\\${electronPath}\\workbench\\workbench.html`
+			: `/${electronPath}/workbench/workbench.html`);
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");

--- a/src/extension.js
+++ b/src/extension.js
@@ -30,14 +30,14 @@ function activate(context) {
 		const htmlFile =
 			base +
 			(isWin
-				? "\\electron-browser\\workbench\\workbench.html"
-				: "/electron-browser/workbench/workbench.html");
+				? "\\electron-sandbox\\workbench\\workbench.html"
+				: "/electron-sandbox/workbench/workbench.html");
 
 		const templateFile =
 				base +
 				(isWin
-					? "\\electron-browser\\workbench\\neondreams.js"
-					: "/electron-browser/workbench/neondreams.js");
+					? "\\electron-sandbox\\workbench\\neondreams.js"
+					: "/electron-sandbox/workbench/neondreams.js");
 
 		try {
 
@@ -109,8 +109,8 @@ function uninstall() {
 	var htmlFile =
 		base +
 		(isWin
-			? "\\electron-browser\\workbench\\workbench.html"
-			: "/electron-browser/workbench/workbench.html");
+			? "\\electron-sandbox\\workbench\\workbench.html"
+			: "/electron-sandbox/workbench/workbench.html");
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");


### PR DESCRIPTION
As shown in #263 the fix by @mcpads is fixed with the addition of `electron-sandbox` instead of `electron-browser`.
`electron-browser` was removed in commit https://github.com/microsoft/vscode/tree/f4f1b04d872a2b94d9a5105a1eefb81a213c07f2 and was renamed.

These lines need to be changed:
https://github.com/robb0wen/synthwave-vscode/blob/07273cd1e1fb6d0873dd96ab9f2e291eb136bee5/src/extension.js#L30-L40

https://github.com/robb0wen/synthwave-vscode/blob/07273cd1e1fb6d0873dd96ab9f2e291eb136bee5/src/extension.js#L109-L113