### PR TITLE
Update VS Code to v1.70.0 Breaks Neon Glow - This PR Fixes Glow Feature

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -30,14 +30,14 @@ function activate(context) {
 		const htmlFile =
 			base +
 			(isWin
-				? "\\electron-browser\\workbench\\workbench.html"
-				: "/electron-browser/workbench/workbench.html");
+				? "\\electron-sandbox\\workbench\\workbench.html"
+				: "/electron-sandbox/workbench/workbench.html");
 
 		const templateFile =
 				base +
 				(isWin
-					? "\\electron-browser\\workbench\\neondreams.js"
-					: "/electron-browser/workbench/neondreams.js");
+					? "\\electron-sandbox\\workbench\\neondreams.js"
+					: "/electron-sandbox/workbench/neondreams.js");
 
 		try {
 
@@ -109,8 +109,8 @@ function uninstall() {
 	var htmlFile =
 		base +
 		(isWin
-			? "\\electron-browser\\workbench\\workbench.html"
-			: "/electron-browser/workbench/workbench.html");
+			? "\\electron-sandbox\\workbench\\workbench.html"
+			: "/electron-sandbox/workbench/workbench.html");
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");

--- a/src/extension.js
+++ b/src/extension.js
@@ -26,18 +26,19 @@ function activate(context) {
 		const isWin = /^win/.test(process.platform);
 		const appDir = path.dirname(require.main.filename);
 		const base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+		const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
 		const htmlFile =
 			base +
 			(isWin
-				? "\\electron-sandbox\\workbench\\workbench.html"
-				: "/electron-sandbox/workbench/workbench.html");
+				? "\\"+electronBase+"\\workbench\\workbench.html"
+				: "/"+electronBase+"/workbench/workbench.html");
 
 		const templateFile =
 				base +
 				(isWin
-					? "\\electron-sandbox\\workbench\\neondreams.js"
-					: "/electron-sandbox/workbench/neondreams.js");
+					? "\\"+electronBase+"\\workbench\\neondreams.js"
+					: "/"+electronBase+"/workbench/neondreams.js");
 
 		try {
 
@@ -106,11 +107,13 @@ function uninstall() {
 	var isWin = /^win/.test(process.platform);
 	var appDir = path.dirname(require.main.filename);
 	var base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
+
 	var htmlFile =
 		base +
 		(isWin
-			? "\\electron-sandbox\\workbench\\workbench.html"
-			: "/electron-sandbox/workbench/workbench.html");
+			? "\\"+electronBase+"\\workbench\\workbench.html"
+			: "/"+electronBase+"/workbench/workbench.html");
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");
@@ -131,6 +134,22 @@ function uninstall() {
 	} else {
 		vscode.window.showInformationMessage('Neon dreams isn\'t running.');
 	}
+}
+
+// Returns true if the VS Code version running this extension is below the
+// version specified in the "version" parameter. Otherwise returns false.
+function isVSCodeBelowVersion(version) {
+	const vscodeVersion = vscode.version;
+	const vscodeVersionArray = vscodeVersion.split('.');
+	const versionArray = version.split('.');
+	
+	for (let i = 0; i < versionArray.length; i++) {
+		if (vscodeVersionArray[i] < versionArray[i]) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 module.exports = {

--- a/src/js/theme_template.js
+++ b/src/js/theme_template.js
@@ -17,19 +17,19 @@
     
     if (!disableGlow) {
       /* replace neon red */
-      updatedThemeStyles = updatedThemeStyles.replace(/color: #fe4450;/g, "color: #fff5f6; text-shadow: 0 0 2px #000, 0 0 10px #fc1f2c[NEON_BRIGHTNESS], 0 0 5px #fc1f2c[NEON_BRIGHTNESS], 0 0 25px #fc1f2c[NEON_BRIGHTNESS]; backface-visibility: hidden;");
+      updatedThemeStyles = updatedThemeStyles.replace(/color: #fe4450;/gi, "color: #fff5f6; text-shadow: 0 0 2px #000, 0 0 10px #fc1f2c[NEON_BRIGHTNESS], 0 0 5px #fc1f2c[NEON_BRIGHTNESS], 0 0 25px #fc1f2c[NEON_BRIGHTNESS]; backface-visibility: hidden;");
       
       /* replace neon pink */
-      updatedThemeStyles = updatedThemeStyles.replace(/color: #ff7edb;/g, "color: #f92aad; text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3; backface-visibility: hidden;");
+      updatedThemeStyles = updatedThemeStyles.replace(/color: #ff7edb;/gi, "color: #f92aad; text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3; backface-visibility: hidden;");
       
       /* replace yellow */
-      updatedThemeStyles = updatedThemeStyles.replace(/color: #fede5d;/g, "color: #f4eee4; text-shadow: 0 0 2px #393a33, 0 0 8px #f39f05[NEON_BRIGHTNESS], 0 0 2px #f39f05[NEON_BRIGHTNESS]; backface-visibility: hidden;");
+      updatedThemeStyles = updatedThemeStyles.replace(/color: #fede5d;/gi, "color: #f4eee4; text-shadow: 0 0 2px #393a33, 0 0 8px #f39f05[NEON_BRIGHTNESS], 0 0 2px #f39f05[NEON_BRIGHTNESS]; backface-visibility: hidden;");
       
       /* replace green */
-      updatedThemeStyles = updatedThemeStyles.replace(/color: #72f1b8;/g, "color: #72f1b8; text-shadow: 0 0 2px #100c0f, 0 0 10px #257c55[NEON_BRIGHTNESS], 0 0 35px #212724[NEON_BRIGHTNESS]; backface-visibility: hidden;");
+      updatedThemeStyles = updatedThemeStyles.replace(/color: #72f1b8;/gi, "color: #72f1b8; text-shadow: 0 0 2px #100c0f, 0 0 10px #257c55[NEON_BRIGHTNESS], 0 0 35px #212724[NEON_BRIGHTNESS]; backface-visibility: hidden;");
       
       /* replace blue */
-      updatedThemeStyles = updatedThemeStyles.replace(/color: #36f9f6;/g, "color: #fdfdfd; text-shadow: 0 0 2px #001716, 0 0 3px #03edf9[NEON_BRIGHTNESS], 0 0 5px #03edf9[NEON_BRIGHTNESS], 0 0 8px #03edf9[NEON_BRIGHTNESS]; backface-visibility: hidden;");
+      updatedThemeStyles = updatedThemeStyles.replace(/color: #36f9f6;/gi, "color: #fdfdfd; text-shadow: 0 0 2px #001716, 0 0 3px #03edf9[NEON_BRIGHTNESS], 0 0 5px #03edf9[NEON_BRIGHTNESS], 0 0 8px #03edf9[NEON_BRIGHTNESS]; backface-visibility: hidden;");
     }
 
     /* append the remaining styles */


### PR DESCRIPTION
The latest update to VS Code v1.70.0 broke the neon activation part of this theme. This is because the location of VS Code's workbench.html moved from "<base_dir>/Contents/Resources/app/out/vs/code/electron-browser/workbench/" to "<base_dir>/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/." So I added some code to check the VSC version and use the correct directory path.