### PR TITLE
change the JSX Open/Closing Tag Background Color

### DIFF
--- a/themes/synthwave-color-theme.json
+++ b/themes/synthwave-color-theme.json
@@ -61,7 +61,7 @@
     "editorCursor.foreground": "#f97e72",
     "editor.selectionBackground": "#ffffff20",
     "editor.selectionHighlightBackground": "#ffffff20",
-    "editor.wordHighlightBackground": "#34294f88",
+    "editor.wordHighlightBackground": "#493a6e88",
     "editor.wordHighlightStrongBackground": "#34294f88",
     "editor.findMatchBackground": "#D18616bb",
     "editor.findMatchHighlightBackground": "#D1861655",


### PR DESCRIPTION
When you click on the open tag in JSX you should see a highlighted background of the closing and opening Tags but It is barely visible. You could only see a good contrast background if you double-click on the tag name, so I changed the color for the single press (editor.wordHighlightBackground) to be more visible.