### PR TITLE
Mark as UI extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "engines": {
         "vscode": "^1.33.0"
     },
+    "extensionKind": ["ui"],
     "keywords": [
         "retro",
         "80s"


### PR DESCRIPTION
Marking this as a UI extension will allow users to use the extension in remote workspaces without needing to install it into every remote.