### PR TITLE
Fix minimal compatibility for visual studio code version 1.94 (windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ In your `settings.json` add the key:
 ```
 To see the changes, you need to rerun the activation function. Open your command palette with `Ctrl + Shift + P` or `Shift + ⌘ + P` and choose "__Enable Neon Dreams__".
 
+### To provide the path to the "workbench.html" file needed to enable "Neon Dreams"
+If the `SynthWave '84` extension cannot find the "workbench.html" file because VScode updated the paths for this file, you need to provide the path manually, either from the extension's configuration interface or from your `settings.json`
+
+The most common path for the "workbench.html" file is:
+```
+(VScode root)\\vs\\code\\electron-sandbox\\workbench\\workbench.html
+```
+
+or for later versions
+```
+(VScode root)\\resources\\app\\out\\vs\\code\\electron-sandbox\\workbench\\workbench.html
+```
+
+NOTE: In case you are on windows, you must separate your directories with "\\\\" double backslash.
+
 ### To remove corruption warning and [unsupported] from title-bar
 Because enabling the glow modifies core files, VS code will interpret this as the core being 'corrupted' and you may see an error message on restarting your editor. You can safely dismiss this message, or remove it entirely with the [Fix VSCode Checksums](https://marketplace.visualstudio.com/items?itemName=lehni.vscode-fix-checksums 'Fix VSCode Checksums') extension.
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Disable the glow effect, but show Synthwave '84 editor chrome updates"
+                },
+                "synthwave84.workbencHtmlPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The path to the file \"workbench.html\""
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "synthwave-vscode",
     "displayName": "SynthWave '84",
     "description": "A Synthwave-inspired colour theme to satisfy your neon dreams",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "author": "Robb Owen",
     "publisher": "RobbOwen",
     "icon": "icon.png",

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,7 +25,7 @@ function activate(context) {
 
 		const isWin = /^win/.test(process.platform);
 		const appDir = path.dirname(require?.main?.filename || process.execPath);
-		const base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+		const base = getWorkbenchPath(appDir);
 		const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
 		const htmlFile =
@@ -106,7 +106,7 @@ function deactivate() {
 function uninstall() {
 	var isWin = /^win/.test(process.platform);
 	var appDir = path.dirname(require?.main?.filename || process.execPath);
-	var base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+	var base = getWorkbenchPath(appDir);
 	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
 	var htmlFile =
@@ -150,6 +150,25 @@ function isVSCodeBelowVersion(version) {
 	}
 
 	return false;
+}
+
+/**
+ * @function getWorkbenchPath
+ * @description returns a text string with the path of the VScode resources where the workbench is located
+ * depending on whether the system is Windows and the VScode version is later than 1.94.0.
+ * @param {string} extensionDir VScode root path
+ * @returns {string} VSCResourcesPath VScode resources path
+*/
+
+function getWorkbenchPath(extensionDir) {
+	const isWin = /^win/.test(process.platform);
+	let VSCResourcesPath = extensionDir;
+	if (isWin) {
+		VSCResourcesPath += `${isVSCodeBelowVersion("1.94.0") ? "\\vs\\code" : "\\resources\\app\\out\\vs\\code"}`;
+	} else {
+		VSCResourcesPath += `${isVSCodeBelowVersion("1.94.0") ? "/vs/code" : "/resources/app/out/vs/code"}`;
+	}
+	return VSCResourcesPath;
 }
 
 module.exports = {

--- a/src/extension.js
+++ b/src/extension.js
@@ -104,35 +104,45 @@ function deactivate() {
 }
 
 function uninstall() {
-	var isWin = /^win/.test(process.platform);
-	var appDir = path.dirname(require?.main?.filename || process.execPath);
-	var base = getWorkbenchPath(appDir);
-	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
+	try {
+		var isWin = /^win/.test(process.platform);
+		var appDir = path.dirname(require?.main?.filename || process.execPath);
+		var base = getWorkbenchPath(appDir);
+		var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
-	var htmlFile =
-		base +
-		(isWin
-			? "\\"+electronBase+"\\workbench\\workbench.esm.html"
-			: "/"+electronBase+"/workbench/workbench.html");
+		var htmlFile =
+			base +
+			(isWin
+				? "\\"+electronBase+"\\workbench\\workbench.esm.html"
+				: "/"+electronBase+"/workbench/workbench.html");
 
-	// modify workbench html
-	const html = fs.readFileSync(htmlFile, "utf-8");
+		// modify workbench html
+		const html = fs.readFileSync(htmlFile, "utf-8");
 
-	// check if the tag is already there
-	const isEnabled = html.includes("neondreams.js");
+		// check if the tag is already there
+		const isEnabled = html.includes("neondreams.js");
 
-	if (isEnabled) {
-		// delete synthwave script tag if there
-		let output = html.replace(/^.*(<!-- SYNTHWAVE 84 --><script src="neondreams.js"><\/script><!-- NEON DREAMS -->).*\n?/mg, '');
-		fs.writeFileSync(htmlFile, output, "utf-8");
+		if (isEnabled) {
+			// delete synthwave script tag if there
+			let output = html.replace(/^.*(<!-- SYNTHWAVE 84 --><script src="neondreams.js"><\/script><!-- NEON DREAMS -->).*\n?/mg, '');
+			fs.writeFileSync(htmlFile, output, "utf-8");
 
-		vscode.window
-			.showInformationMessage("Neon Dreams disabled. VS code must reload for this change to take effect", { title: "Restart editor to complete" })
-			.then(function(msg) {
-				vscode.commands.executeCommand("workbench.action.reloadWindow");
-			});
-	} else {
-		vscode.window.showInformationMessage('Neon dreams isn\'t running.');
+			vscode.window
+				.showInformationMessage("Neon Dreams disabled. VS code must reload for this change to take effect", { title: "Restart editor to complete" })
+				.then(function(msg) {
+					vscode.commands.executeCommand("workbench.action.reloadWindow");
+				});
+		} else {
+			vscode.window.showInformationMessage('Neon dreams isn\'t running.');
+		}
+	} catch (error) {
+		if (/ENOENT|EACCES|EPERM/.test(error.code)) {
+			vscode.window.showInformationMessage("Neon Dreams was unable to modify the core VS code files needed to launch the extension. You may need to run VS code with admin privileges in order to enable Neon Dreams.");
+			return;
+		} else {
+			vscode.window.showErrorMessage('Something went wrong when starting neon dreams');
+			return;
+		}
 	}
 }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,7 +24,7 @@ function activate(context) {
 	let disposable = vscode.commands.registerCommand('synthwave84.enableNeon', function () {
 
 		const isWin = /^win/.test(process.platform);
-		const appDir = path.dirname(require.main.filename);
+		const appDir = path.dirname(require?.main?.filename || process.execPath);
 		const base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
 		const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
@@ -105,7 +105,7 @@ function deactivate() {
 
 function uninstall() {
 	var isWin = /^win/.test(process.platform);
-	var appDir = path.dirname(require.main.filename);
+	var appDir = path.dirname(require?.main?.filename || process.execPath);
 	var base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
 	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,7 +31,7 @@ function activate(context) {
 		const htmlFile =
 			base +
 			(isWin
-				? "\\"+electronBase+"\\workbench\\workbench.html"
+				? "\\"+electronBase+"\\workbench\\workbench.esm.html"
 				: "/"+electronBase+"/workbench/workbench.html");
 
 		const templateFile =
@@ -112,7 +112,7 @@ function uninstall() {
 	var htmlFile =
 		base +
 		(isWin
-			? "\\"+electronBase+"\\workbench\\workbench.html"
+			? "\\"+electronBase+"\\workbench\\workbench.esm.html"
 			: "/"+electronBase+"/workbench/workbench.html");
 
 	// modify workbench html

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,7 +31,7 @@ function activate(context) {
 			return vscode.window.showInformationMessage(`No path found for "workbench.html", you can provide one in the extension configuration interface or "settings.json"`);
 		}
 
-		const workbenchJsPath = workbenchHtmlPath.split(/[\/,\\\\]/).slice(0,-1).join("") + "neondreams.js";
+		const workbenchJsPath = path.join(path.dirname(workbenchHtmlPath), "neondreams.js");
 
 		try {
 			// generate production theme JS

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,7 +25,12 @@ function activate(context) {
 	const disposable = vscode.commands.registerCommand('synthwave84.enableNeon', function () {
 
 		const vscodeDir = path.dirname(require?.main?.filename || process.execPath);
-		const workbenchHtmlPath = workbencHtmlPath ? workbencHtmlPath : recursiveSearchPath(vscodeDir, "workbench", "html");
+		const workbenchHtmlPath = workbencHtmlPath || recursiveSearchPath(vscodeDir, "workbench", "html");
+
+		if (!workbenchHtmlPath) {
+			return vscode.window.showInformationMessage(`No path found for "workbench.html", you can provide one in the extension configuration interface or "settings.json"`);
+		}
+
 		const workbenchJsPath = workbenchHtmlPath.split(/[\/,\\\\]/).slice(0,-1).join("") + "neondreams.js";
 
 		try {


### PR DESCRIPTION
This version fixes compatibility to enable "Neon Dreams" in VScode 1.94.

fix #320

**Note: Only changes from the new version of VScode (1.94) on Windows were taken into account.** EDIT*: functionality for older versions is still maintained.

1. Now enabling and disabling (admin mode) "Neon Dreams" does not throw an error.

2. Error messages when disabling "Neon Dreams" will now be displayed in a popup in the VScode interface.

EDIT*:

1. The functionality has been adjusted so that the extension can perform a more precise search for the necessary files, taking advantage of the features that node provides with respect to system accessibility.

2. Now the user will be able to provide the path of the "workbench.html" file manually, from the configuration interface or the "settings.json" as:

`workbencHtmlPath` property.

![image](https://github.com/user-attachments/assets/45ff0f0c-5021-49f2-ab09-8c9a5528ab69)

or

![image](https://github.com/user-attachments/assets/e6d3ca41-1ce5-47e6-9703-31928c20a6e7)

