### PR TITLE
bug(#320): fix filename undefined error when loading extesion with vscode version 1.94.0 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "synthwave-vscode",
     "displayName": "SynthWave '84",
     "description": "A Synthwave-inspired colour theme to satisfy your neon dreams",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "author": "Robb Owen",
     "publisher": "RobbOwen",
     "icon": "icon.png",

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,15 +24,15 @@ function activate(context) {
 	let disposable = vscode.commands.registerCommand('synthwave84.enableNeon', function () {
 
 		const isWin = /^win/.test(process.platform);
-		const appDir = path.dirname(require.main.filename);
-		const base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+		const appDir = path.dirname(vscode.env.appRoot);
+		const base = appDir + (isWin ? "\\app\\out\\vs\\code" : "/app/out/vs/code");
 		const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
 		const htmlFile =
 			base +
 			(isWin
-				? "\\"+electronBase+"\\workbench\\workbench.html"
-				: "/"+electronBase+"/workbench/workbench.html");
+				? "\\"+electronBase+"\\workbench\\workbench.esm.html"
+				: "/"+electronBase+"/workbench/workbench.esm.html");
 
 		const templateFile =
 				base +

--- a/src/extension.js
+++ b/src/extension.js
@@ -105,15 +105,15 @@ function deactivate() {
 
 function uninstall() {
 	var isWin = /^win/.test(process.platform);
-	var appDir = path.dirname(require.main.filename);
-	var base = appDir + (isWin ? "\\vs\\code" : "/vs/code");
+	const appDir = path.dirname(vscode.env.appRoot);
+	const base = appDir + (isWin ? "\\app\\out\\vs\\code" : "/app/out/vs/code");
 	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
 
 	var htmlFile =
 		base +
 		(isWin
-			? "\\"+electronBase+"\\workbench\\workbench.html"
-			: "/"+electronBase+"/workbench/workbench.html");
+			? "\\"+electronBase+"\\workbench\\workbench.esm.html"
+			: "/"+electronBase+"/workbench/workbench.esm.html");
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");

--- a/src/extension.js
+++ b/src/extension.js
@@ -23,22 +23,13 @@ function activate(context) {
 
 	let disposable = vscode.commands.registerCommand('synthwave84.enableNeon', function () {
 
-		const isWin = /^win/.test(process.platform);
 		const appDir = path.dirname(vscode.env.appRoot);
-		const base = appDir + (isWin ? "\\app\\out\\vs\\code" : "/app/out/vs/code");
+		const base = path.join(appDir,'app','out','vs','code');
 		const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
+		const workBenchFilename = isVSCodeBelowVersion("1.94.0") ? "workbench.html" : "workbench.esm.html";
 
-		const htmlFile =
-			base +
-			(isWin
-				? "\\"+electronBase+"\\workbench\\workbench.esm.html"
-				: "/"+electronBase+"/workbench/workbench.esm.html");
-
-		const templateFile =
-				base +
-				(isWin
-					? "\\"+electronBase+"\\workbench\\neondreams.js"
-					: "/"+electronBase+"/workbench/neondreams.js");
+		const htmlFile = path.join(base, electronBase, "workbench", workBenchFilename);
+		const templateFile = path.join(base, electronBase, "workbench", "neondreams.js");
 
 		try {
 
@@ -104,16 +95,12 @@ function deactivate() {
 }
 
 function uninstall() {
-	var isWin = /^win/.test(process.platform);
 	const appDir = path.dirname(vscode.env.appRoot);
-	const base = appDir + (isWin ? "\\app\\out\\vs\\code" : "/app/out/vs/code");
-	var electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
+	const base = path.join(appDir, 'app', 'out', 'vs', 'code');
+	const electronBase = isVSCodeBelowVersion("1.70.0") ? "electron-browser" : "electron-sandbox";
+	const workBenchFilename = isVSCodeBelowVersion("1.94.0") ? "workbench.html" : "workbench.esm.html";
 
-	var htmlFile =
-		base +
-		(isWin
-			? "\\"+electronBase+"\\workbench\\workbench.esm.html"
-			: "/"+electronBase+"/workbench/workbench.esm.html");
+	const htmlFile = path.join(base, electronBase, "workbench", workBenchFilename);
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");


### PR DESCRIPTION
this should resolve the issue that after an update of vscode (>= v1.94) the extension no longer is loading.

[origin of solution](https://github.com/robb0wen/synthwave-vscode/issues/326#issuecomment-2402593191)